### PR TITLE
chore: homepage link for easy routing from npm page to github

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "version": "1.0.2",
     "description": "Simple middleware to display routes in an express application",
     "main": "lib/index.js",
-    "repository": "git@github.com:BolajiOlajide/koi.git",
-    "homepage": "https://github.com/BolajiOlajide/koi",
+    "repository": "git@github.com:BolajiOlajide/koii.git",
+    "homepage": "https://github.com/BolajiOlajide/koii",
     "author": "BolajiOlajide",
     "license": "MIT",
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Simple middleware to display routes in an express application",
     "main": "lib/index.js",
     "repository": "git@github.com:BolajiOlajide/koi.git",
+    "homepage": "https://github.com/BolajiOlajide/koi",
     "author": "BolajiOlajide",
     "license": "MIT",
     "devDependencies": {


### PR DESCRIPTION
When I opened the package: https://www.npmjs.com/package/koii, I was unable to route to the source code; I had to go back to ur post in DC slack

<img width="748" alt="screenshot 2019-01-04 at 10 11 37 am" src="https://user-images.githubusercontent.com/10440327/50680791-47640c80-1009-11e9-91c3-d39b4e3a9900.png">

Now it should have 
<img width="538" alt="screenshot 2019-01-04 at 10 15 21 am" src="https://user-images.githubusercontent.com/10440327/50680911-c3f6eb00-1009-11e9-9ba5-66fdb5d0bf9b.png">

