### PR TITLE
docs: image shield for correct npm pkg version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![star this repo](http://githubbadges.com/star.svg?user=BolajiOlajide&repo=koii&style=flat)](https://github.com/BolajiOlajide/koi)
 [![fork this repo](http://githubbadges.com/fork.svg?user=BolajiOlajide&repo=koii&style=flat)](https://github.com/BolajiOlajide/koi/fork)
-[![NPM version](https://badge.fury.io/js/badge-list.svg)](http://badge.fury.io/js/badge-list)
+[![npm](https://img.shields.io/npm/v/koii.svg)](https://www.npmjs.com/package/koii)
 [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=102)](https://github.com/ellerbrock/open-source-badge/)
 [![Open Source Love](https://badges.frapsoft.com/os/mit/mit.svg?v=102)](https://github.com/ellerbrock/open-source-badge/)
 


### PR DESCRIPTION
#### before 
[![NPM version](https://badge.fury.io/js/badge-list.svg)](http://badge.fury.io/js/badge-list)

#### now
[![npm](https://img.shields.io/npm/v/koii.svg)](https://www.npmjs.com/package/koii)

with a correct link to the npm package not to badge-list